### PR TITLE
added krb5_use_enterprise_principal to default sssd.conf

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'adaptavist-sssd'
-version '1.0.0'
+version '1.0.1'
 author 'Evgeny Zislis <ezislis@adaptavist.com>'
 summary 'Manage SSSD authentication and configuration.' 
 license 'Apache2'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,9 @@
 # [*debug_level*]
 # Used to specify the debug level.
 #
+# [*ldap_krb5_enterprise_principal*]
+# sets krb5_use_enterprise_principal flad in sssd.conf
+#
 # === Example
 #
 # class { 'sssd':
@@ -51,16 +54,17 @@
 # Copyright 2014 Adaptavist Ltd, unless otherwise noted.
 #
 class sssd (
-  $type                  = 'default',
-  $domains               = [],
-  $filter_users          = [ 'root' ],
-  $filter_groups         = [ 'root' ],
-  $custom_template       = undef,
-  $ldap_search_base      = undef,
-  $cert_name             = undef,
-  $ldap_default_bind_uid = 'com',
-  $ldap_default_authtok  = undef,
-  $debug_level           = '9',
+  $type                           = 'default',
+  $domains                        = [],
+  $filter_users                   = [ 'root' ],
+  $filter_groups                  = [ 'root' ],
+  $custom_template                = undef,
+  $ldap_search_base               = undef,
+  $cert_name                      = undef,
+  $ldap_default_bind_uid          = 'com',
+  $ldap_default_authtok           = undef,
+  $ldap_krb5_enterprise_principal = false,
+  $debug_level                    = '9',
 ) {
   validate_array($domains)
   validate_array($filter_users)
@@ -110,6 +114,9 @@ class sssd (
   if $custom_template {
     $template = $custom_template
   }
+
+  #work out the boolean value for real_krb5_enterprise_principal
+  $real_krb5_enterprise_principal = str2bool($ldap_krb5_enterprise_principal)
 
   package { $packages : }
     -> file { '/etc/sssd/sssd.conf':

--- a/templates/sssd_default.conf.erb
+++ b/templates/sssd_default.conf.erb
@@ -13,6 +13,7 @@ ldap_default_bind_dn = <%= "uid=#{@ldap_default_bind_uid},#{@ldap_search_base}" 
 ldap_default_authtok = <%= @ldap_default_authtok %>
 ldap_tls_cacertdir = <%= @ldap_tls_cacertdir %>
 enumerate = true
+krb5_use_enterprise_principal = <%= @real_krb5_enterprise_principal %>
 [sssd]
 services = nss, pam
 config_file_version = 2


### PR DESCRIPTION
added krb5_use_enterprise_principal to sssd.conf and defaulted to false, as having it true with openldap stops users changing passwords with the linux "passwd" command